### PR TITLE
Fix assembly functions pointer handling

### DIFF
--- a/src/decision_engine.asm
+++ b/src/decision_engine.asm
@@ -3,6 +3,7 @@ section .data
 
 section .text
     global decision_engine_main
+    extern write_output
 
 decision_engine_main:
     mov rdi, decision_msg

--- a/src/io_handler.asm
+++ b/src/io_handler.asm
@@ -13,9 +13,10 @@ read_input:
     ret
 
 write_output:
+    push rdi            ; save pointer to output buffer
     mov rax, 1          ; syscall: write
     mov rdi, 1          ; stdout
-    mov rsi, rdi        ; Output buffer
+    pop rsi             ; restore buffer pointer
     mov rdx, 256        ; Output size
     syscall
     ret

--- a/src/main.asm
+++ b/src/main.asm
@@ -6,6 +6,9 @@ section .bss
 
 section .text
     global _start
+    extern init_memory_manager
+    extern neural_network_main
+    extern decision_engine_main
 
 _start:
     ; Print welcome message
@@ -28,9 +31,10 @@ _start:
 
 print_string:
     ; Print a null-terminated string
+    push rdi            ; preserve pointer to string
     mov rax, 1          ; syscall: write
     mov rdi, 1          ; file descriptor: stdout
-    mov rsi, rdi        ; string address
+    pop rsi             ; restore string address
     mov rdx, 25         ; string length
     syscall
     ret

--- a/src/memory_manager.asm
+++ b/src/memory_manager.asm
@@ -1,21 +1,23 @@
 section .bss
     heap_start resb 1024
-    heap_end resb 0
+    heap_end   resq 1        ; pointer to end of heap
 
 section .text
     global init_memory_manager, allocate_memory, free_memory
 
 init_memory_manager:
-    mov rdi, heap_start
-    mov rsi, heap_end
+    lea rax, [heap_start]
+    mov [heap_end], rax
     ret
 
 allocate_memory:
-    mov rax, rdi        ; Requested size
-    add rsi, rax        ; Move heap end
-    mov rax, rsi        ; Return pointer to allocated block
+    mov rax, [heap_end] ; Current heap end
+    mov rdx, rdi        ; Requested size
+    add [heap_end], rdx ; Update heap end
+    ; Return pointer to allocated block in rax
     ret
 
 free_memory:
-    mov rsi, rdi        ; Reset heap end to start
+    lea rax, [heap_start]
+    mov [heap_end], rax
     ret

--- a/src/neural_network.asm
+++ b/src/neural_network.asm
@@ -14,8 +14,9 @@ neural_network_main:
     xor rcx, rcx        ; Clear counter
     .loop:
         mov al, [rsi + rcx]  ; Load weight
-        imul al, [rdi + rcx] ; Multiply by input
-        add [rdx + rcx], al  ; Add to output
+        mov bl, [rdi + rcx]  ; Load input
+        imul bl              ; Multiply AL by BL -> AX
+        add [rdx + rcx], al  ; Add low byte of result to output
         inc rcx              ; Increment counter
         cmp rcx, 2           ; Check if done
         jl .loop


### PR DESCRIPTION
## Summary
- fix print_string to preserve string pointer before writing
- fix write_output to use passed buffer pointer
- rewrite memory manager to maintain heap pointer correctly
- correct neural network multiply instruction
- declare extern dependencies for proper linking

## Testing
- `bash tools/build.sh`
- `./agi_system`

------
https://chatgpt.com/codex/tasks/task_e_6849e5e99224832e951052b2940f3ad6