### PR TITLE
Add assembly tests and test runner

### DIFF
--- a/src/neural_network.asm
+++ b/src/neural_network.asm
@@ -1,4 +1,5 @@
 section .data
+    global weights, inputs, output
     weights db 1, 2, 3, 4
     inputs db 5, 6
     output resb 2
@@ -13,11 +14,12 @@ neural_network_main:
 
     xor rcx, rcx        ; Clear counter
     .loop:
-        mov al, [rsi + rcx]  ; Load weight
-        imul al, [rdi + rcx] ; Multiply by input
-        add [rdx + rcx], al  ; Add to output
-        inc rcx              ; Increment counter
-        cmp rcx, 2           ; Check if done
+        movzx rax, byte [rsi + rcx]  ; Load weight
+        movzx rbx, byte [rdi + rcx]  ; Load input
+        imul rax, rbx                ; Multiply
+        add [rdx + rcx], al          ; Add low byte of result
+        inc rcx                      ; Increment counter
+        cmp rcx, 2                   ; Check if done
         jl .loop
 
     ret

--- a/tests/test_io.asm
+++ b/tests/test_io.asm
@@ -1,8 +1,23 @@
 section .text
-    global test_io
+    global _start, test_io
+    extern read_input, write_output
+
+_start:
+    call test_io
+    mov rdi, rax        ; exit code from test
+    mov rax, 60         ; syscall: exit
+    syscall
 
 test_io:
     call read_input
+    cmp rax, 0
+    jl fail
     call write_output
-    ; Add assertions to verify I/O operations
+    cmp rax, 0
+    jl fail
+    xor rax, rax
+    ret
+
+fail:
+    mov rax, 1
     ret

--- a/tests/test_memory.asm
+++ b/tests/test_memory.asm
@@ -1,8 +1,26 @@
 section .text
-    global test_memory
+    global _start, test_memory
+    extern init_memory_manager, allocate_memory, free_memory
+
+_start:
+    call test_memory
+    mov rdi, rax        ; exit code
+    mov rax, 60         ; syscall: exit
+    syscall
 
 test_memory:
     call init_memory_manager
+    mov rdi, 16
     call allocate_memory
-    ; Add assertions to verify memory allocation
+    cmp rax, rsi
+    jne fail
+    mov rdi, 0
+    call free_memory
+    cmp rsi, 0
+    jne fail
+    xor rax, rax
+    ret
+
+fail:
+    mov rax, 1
     ret

--- a/tests/test_neural_net.asm
+++ b/tests/test_neural_net.asm
@@ -1,7 +1,25 @@
 section .text
-    global test_neural_net
+    global _start, test_neural_net
+    extern neural_network_main
+    extern output
+
+_start:
+    call test_neural_net
+    mov rdi, rax
+    mov rax, 60
+    syscall
 
 test_neural_net:
     call neural_network_main
-    ; Add assertions to verify output
+    mov al, [output]
+    cmp al, 5
+    jne fail
+    mov al, [output + 1]
+    cmp al, 12
+    jne fail
+    xor rax, rax
+    ret
+
+fail:
+    mov rax, 1
     ret

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+assemble() {
+    nasm -f elf64 -o "$2" "$1"
+}
+
+run_test() {
+    local test_file=$1
+    shift
+    echo "Building $test_file"
+    objs=""
+    for src in "$@"; do
+        obj="$(basename "${src%.asm}.o")"
+        assemble "$src" "$obj"
+        objs+=" $obj"
+    done
+    assemble "tests/$test_file.asm" "$test_file.o"
+    ld -o "$test_file" "$test_file.o" $objs
+    echo "Running $test_file"
+    if ./${test_file} < /dev/null; then
+        echo "$test_file: PASS"
+    else
+        echo "$test_file: FAIL"
+        FAILURES=1
+    fi
+}
+
+FAILURES=0
+run_test test_io src/io_handler.asm
+run_test test_memory src/memory_manager.asm
+run_test test_neural_net src/neural_network.asm
+
+if [ "$FAILURES" -eq 0 ]; then
+    echo "All tests passed."
+else
+    echo "Some tests failed." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add simple checks to `tests/test_io.asm`, `tests/test_memory.asm` and `tests/test_neural_net.asm`
- expose data in `src/neural_network.asm` and fix invalid `imul` instruction
- provide `tools/test.sh` to build and execute the assembly tests

## Testing
- `bash tools/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849eae3480c832e8028159b85b6629a